### PR TITLE
Revamp hero experience with Opera Neon-inspired styling

### DIFF
--- a/intleri-demo/src/app/globals.css
+++ b/intleri-demo/src/app/globals.css
@@ -76,6 +76,46 @@
   text-shadow: 0 0 10px rgba(99,230,255,0.5);
 }
 
+/* Ambient gradients + grid inspired by Opera Neon */
+.hero-surface {
+  background:
+    radial-gradient(120% 120% at 0% 0%, rgba(99, 230, 255, 0.18), rgba(10, 15, 20, 0) 55%),
+    radial-gradient(110% 120% at 100% 5%, rgba(167, 139, 250, 0.2), rgba(10, 15, 20, 0) 60%),
+    linear-gradient(160deg, rgba(10, 15, 20, 0.9), rgba(10, 15, 20, 0.6));
+}
+
+.hero-grid {
+  background-image: radial-gradient(rgba(99, 230, 255, 0.12) 1px, transparent 0);
+  background-size: 48px 48px;
+  mask-image: radial-gradient(circle at center, rgba(0, 0, 0, 0.65), transparent 70%);
+  -webkit-mask-image: radial-gradient(circle at center, rgba(0, 0, 0, 0.65), transparent 70%);
+}
+
+.hero-noise {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)' opacity='0.28'/%3E%3C/svg%3E");
+  mix-blend-mode: screen;
+  opacity: 0.15;
+}
+
+.gradient-border {
+  position: relative;
+}
+
+.gradient-border::after {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  background: linear-gradient(140deg, rgba(99,230,255,0.5), rgba(167,139,250,0.35));
+  opacity: 0.4;
+  z-index: -1;
+  transition: opacity 0.3s ease;
+}
+
+.gradient-border:hover::after {
+  opacity: 0.75;
+}
+
 /* Custom scrollbar */
 ::-webkit-scrollbar {
   width: 8px;

--- a/intleri-demo/src/components/BentoGrid.tsx
+++ b/intleri-demo/src/components/BentoGrid.tsx
@@ -1,44 +1,63 @@
+"use client";
+
 import { motion } from "framer-motion";
-import { Shield, ChartLine, Truck, Leaf, Radar, Zap } from "lucide-react";
+import {
+  Shield,
+  LayoutDashboard,
+  Waves,
+  Sparkles,
+  CircuitBoard,
+  GaugeCircle
+} from "lucide-react";
+import { cn } from "@/lib/utils";
 import GlassCard from "./GlassCard";
 
 const features = [
   {
-    title: "SECaaS",
-    description: "Tenant isolation, RBAC, fail-closed controls, and ML-assisted anomaly detection with full audit trails.",
+    title: "Command deck",
+    description: "Compose a neon-lit mosaic of cross-domain KPIs, command panels and live automations.",
+    icon: LayoutDashboard,
+    accent: "from-neon-1/20 via-transparent to-neon-2/20",
+    bullets: ["Drag + drop data spaces", "Latency-optimized tiles"],
+    className: "lg:col-span-2"
+  },
+  {
+    title: "Security-as-a-Service",
+    description: "Fail-closed policies, RBAC, and anomaly detection stitched directly into every workflow stage.",
     icon: Shield,
-    className: "col-span-1 md:col-span-2",
+    accent: "from-neon-2/20 via-transparent to-transparent",
+    bullets: ["Continuous compliance states", "Policy-as-code guardrails"]
   },
   {
-    title: "TPI Analytics",
-    description: "Cross-domain KPIs, anomaly detection, forecasting across 19 operational domains.",
-    icon: ChartLine,
-    className: "col-span-1",
+    title: "Signal fabric",
+    description: "Streaming ingestion unifies load boards, carrier telemetry and robotics signals in one fabric.",
+    icon: Waves,
+    accent: "from-neon-3/20 via-transparent to-transparent",
+    bullets: ["Edge caching for robotics", "MCP-native webhooks"],
+    className: "lg:col-span-1"
   },
   {
-    title: "Loadboard → Carrier",
-    description: "Marketplace + execution + unified tracking with geofences and exception handling.",
-    icon: Truck,
-    className: "col-span-1",
+    title: "Predictive copilots",
+    description: "Scenario simulations surface next-best moves, explainability, and ROI before execution.",
+    icon: Sparkles,
+    accent: "from-neon-1/20 via-neon-2/20 to-transparent",
+    bullets: ["Agentic playbooks", "Explainable outlooks"]
   },
   {
-    title: "Emissions",
-    description: "Trip-level capture, targets, rollups with intensity metrics and target tracking.",
-    icon: Leaf,
-    className: "col-span-1",
+    title: "Trusted robotics",
+    description: "TSM orchestrates AMRs, drones and cobots with safety layers, digital twins and override control.",
+    icon: CircuitBoard,
+    accent: "from-neon-2/20 via-transparent to-neon-3/20",
+    bullets: ["ROS bridge & telemetry", "Safety sandbox"]
   },
   {
-    title: "Intelligence",
-    description: "Risk domains scoring, location briefs, executive reports with configurable weights.",
-    icon: Radar,
-    className: "col-span-1",
-  },
-  {
-    title: "TSM & Agents",
-    description: "Tokenized execution, MCP orchestration, and robotics interop with safety protocols.",
-    icon: Zap,
-    className: "col-span-1 md:col-span-2",
-  },
+    title: "Operational ledger",
+    description: "Every decision logged with emissions, spend, and risk provenance for auditors and partners.",
+    icon: GaugeCircle,
+    accent: "from-neon-3/20 via-transparent to-transparent",
+    bullets: ["CO₂ intensity snapshots", "Shared with trading partners"],
+    className: "lg:col-span-1"
+  }
 ];
 
 export default function BentoGrid() {
@@ -61,7 +80,7 @@ export default function BentoGrid() {
           </p>
         </motion.div>
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {features.map((feature, index) => {
             const Icon = feature.icon;
             return (
@@ -73,22 +92,43 @@ export default function BentoGrid() {
                 viewport={{ once: true }}
                 className={feature.className}
               >
-                <GlassCard hover className="h-full">
-                  <div className="flex items-start space-x-4">
-                    <div className="flex-shrink-0">
-                      <div className="w-12 h-12 bg-neon-1/20 rounded-lg flex items-center justify-center">
-                        <Icon className="w-6 h-6 text-neon-1" />
+                <GlassCard
+                  hover
+                  className={cn(
+                    "relative h-full overflow-hidden rounded-3xl border-white/10 bg-white/[0.04] p-6"
+                  )}
+                >
+                  <div
+                    className={cn(
+                      "pointer-events-none absolute inset-0 bg-gradient-to-br opacity-60 transition-opacity duration-500 group-hover:opacity-100",
+                      feature.accent
+                    )}
+                  />
+                  <div className="relative z-10 flex flex-col gap-5">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-3">
+                        <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-white/10 bg-white/[0.08]">
+                          <Icon className="w-6 h-6 text-neon-1" />
+                        </div>
+                        <h3 className="text-xl font-semibold text-text">{feature.title}</h3>
                       </div>
                     </div>
-                    <div className="flex-1">
-                      <h3 className="text-xl font-semibold text-text mb-2">
-                        {feature.title}
-                      </h3>
-                      <p className="text-muted leading-relaxed">
-                        {feature.description}
-                      </p>
-                    </div>
+                    <p className="text-sm text-muted leading-relaxed">{feature.description}</p>
+
+                    {feature.bullets && (
+                      <ul className="mt-auto space-y-2 text-sm text-muted/90">
+                        {feature.bullets.map((bullet) => (
+                          <li key={bullet} className="flex items-center gap-2">
+                            <span className="h-1.5 w-1.5 rounded-full bg-neon-1" />
+                            {bullet}
+                          </li>
+                        ))}
+                      </ul>
+                    )}
                   </div>
+
+                  <div className="pointer-events-none absolute -right-16 -top-16 h-32 w-32 rounded-full bg-neon-1/20 blur-3xl transition-transform duration-500 group-hover:scale-110" />
+                  <div className="pointer-events-none absolute -left-20 bottom-0 h-28 w-28 rounded-full bg-neon-2/10 blur-3xl transition-transform duration-500 group-hover:scale-110" />
                 </GlassCard>
               </motion.div>
             );

--- a/intleri-demo/src/components/GlassCard.tsx
+++ b/intleri-demo/src/components/GlassCard.tsx
@@ -10,7 +10,7 @@ export default function GlassCard({ children, className = "", hover = true }: Gl
   return (
     <div 
       className={cn(
-        "rounded-2xl p-6 transition-all duration-300",
+        "group rounded-2xl p-6 transition-all duration-300",
         hover && "hover:scale-[1.02] hover:shadow-glow",
         className
       )}

--- a/intleri-demo/src/components/Hero.tsx
+++ b/intleri-demo/src/components/Hero.tsx
@@ -1,95 +1,219 @@
+"use client";
+
 import { motion } from "framer-motion";
+import {
+  Sparkles,
+  ShieldCheck,
+  Workflow,
+  Cpu,
+  Radar,
+  ArrowUpRight,
+  LineChart
+} from "lucide-react";
+import GlassCard from "./GlassCard";
 import NeonButton from "./NeonButton";
+
+const highlights = [
+  {
+    icon: ShieldCheck,
+    title: "Zero-trust perimeter",
+    description: "Hardware attestation, tenant isolation and adaptive guardrails."
+  },
+  {
+    icon: Workflow,
+    title: "Composed automations",
+    description: "Design runbooks that branch across TSM, agents and robotics."
+  },
+  {
+    icon: LineChart,
+    title: "Predictive telemetry",
+    description: "Neural forecasting on freight, risk, emissions and financials."
+  },
+  {
+    icon: Cpu,
+    title: "GPU-native fabric",
+    description: "Streaming inference at the edge with MCP-compatible APIs."
+  }
+];
 
 export default function Hero() {
   return (
-    <section className="relative min-h-screen flex items-center justify-center overflow-hidden">
-      {/* Background gradient */}
-      <div className="absolute inset-0 bg-gradient-to-br from-bg via-bg to-neon-1/5" />
-      
-      {/* Animated background elements */}
-      <div className="absolute inset-0 overflow-hidden">
-        <motion.div
-          animate={{
-            x: [0, 100, 0],
-            y: [0, -100, 0],
-          }}
-          transition={{
-            duration: 20,
-            repeat: Infinity,
-            ease: "linear",
-          }}
-          className="absolute top-1/4 left-1/4 w-64 h-64 bg-neon-1/10 rounded-full blur-3xl"
-        />
-        <motion.div
-          animate={{
-            x: [0, -150, 0],
-            y: [0, 100, 0],
-          }}
-          transition={{
-            duration: 25,
-            repeat: Infinity,
-            ease: "linear",
-          }}
-          className="absolute bottom-1/4 right-1/4 w-96 h-96 bg-neon-2/10 rounded-full blur-3xl"
-        />
-      </div>
+    <section className="relative min-h-screen overflow-hidden">
+      <div className="absolute inset-0 hero-surface" />
+      <div className="absolute inset-0 hero-grid opacity-40" />
+      <div className="absolute inset-0 hero-noise" aria-hidden="true" />
 
-      <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-        <motion.div
-          initial={{ opacity: 0, y: 30 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8 }}
-        >
-          <h1 className="text-5xl md:text-7xl font-bold mb-6">
-            <span className="text-text">Intleri</span>
-            <br />
-            <span className="neon-text">Secure, modular logistics intelligence</span>
-          </h1>
-          
-          <motion.p
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8, delay: 0.2 }}
-            className="text-xl md:text-2xl text-muted mb-8 max-w-3xl mx-auto leading-relaxed"
-          >
-            Security-as-a-Service • TPI Analytics • DRF API • Microservices-ready
-          </motion.p>
-
+      <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-32 pb-24">
+        <div className="grid lg:grid-cols-2 gap-16 items-center">
           <motion.div
-            initial={{ opacity: 0, y: 20 }}
+            initial={{ opacity: 0, y: 40 }}
             animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8, delay: 0.4 }}
-            className="flex flex-col sm:flex-row gap-4 justify-center items-center"
+            transition={{ duration: 0.8 }}
+            className="relative"
           >
-            <NeonButton variant="default" size="lg" className="px-8 py-3">
-              View the Platform
-            </NeonButton>
-            <NeonButton variant="neon" size="lg" className="px-8 py-3">
-              Explore the Apps
-            </NeonButton>
+            <div className="inline-flex items-center gap-2 rounded-full glass border border-white/10 px-4 py-2 text-sm text-muted">
+              <Sparkles className="w-4 h-4 text-neon-1" />
+              <span className="text-text/80">Introducing Intleri Neon Control Surface</span>
+            </div>
+
+            <h1 className="mt-8 text-5xl md:text-7xl font-semibold leading-tight tracking-tight">
+              <span className="text-text">Logistics intelligence that feels</span>
+              <span className="block bg-gradient-to-r from-neon-1 via-neon-2 to-neon-3 bg-clip-text text-transparent">
+                like piloting a living control room.
+              </span>
+            </h1>
+
+            <p className="mt-6 text-lg md:text-xl text-muted leading-relaxed max-w-xl">
+              Stream operational context, simulate futures, and deploy trusted automations
+              across your network. A neon-grade experience tuned for high velocity supply
+              chains.
+            </p>
+
+            <div className="mt-10 flex flex-col sm:flex-row gap-4 sm:items-center">
+              <NeonButton variant="neon" size="lg" className="px-8 py-3">
+                Launch the platform
+              </NeonButton>
+              <NeonButton variant="default" size="lg" className="px-8 py-3">
+                View live demos
+              </NeonButton>
+            </div>
+
+            <div className="mt-12 grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {highlights.map((item) => {
+                const Icon = item.icon;
+                return (
+                  <div
+                    key={item.title}
+                    className="gradient-border rounded-2xl bg-white/[0.03] p-4 backdrop-blur-sm border border-white/10 flex gap-3"
+                  >
+                    <div className="flex h-10 w-10 items-center justify-center rounded-full bg-neon-1/10 border border-neon-1/30">
+                      <Icon className="w-5 h-5 text-neon-1" />
+                    </div>
+                    <div>
+                      <h3 className="text-sm font-semibold text-text">{item.title}</h3>
+                      <p className="text-xs text-muted mt-1 leading-relaxed">{item.description}</p>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
           </motion.div>
-        </motion.div>
 
-        {/* Scroll indicator */}
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 1, delay: 1 }}
-          className="absolute bottom-8 left-1/2 transform -translate-x-1/2"
-        >
-          <motion.div
-            animate={{ y: [0, 10, 0] }}
-            transition={{ duration: 2, repeat: Infinity }}
-            className="w-6 h-10 border-2 border-neon-1 rounded-full flex justify-center"
-          >
+          <div className="relative h-[520px]">
             <motion.div
-              animate={{ y: [0, 12, 0] }}
-              transition={{ duration: 2, repeat: Infinity }}
-              className="w-1 h-3 bg-neon-1 rounded-full mt-2"
+              initial={{ opacity: 0, y: 60 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.9, delay: 0.2 }}
+              className="absolute inset-0 flex justify-end"
+            >
+              <GlassCard
+                hover={false}
+                className="relative h-full w-full max-w-[420px] overflow-hidden rounded-3xl border-white/10 bg-white/5 px-8 py-10"
+              >
+                <div className="absolute inset-x-6 top-0 h-px bg-gradient-to-r from-transparent via-neon-1/60 to-transparent" />
+                <div className="flex items-start justify-between">
+                  <div>
+                    <p className="text-xs uppercase tracking-widest text-muted">Network pulse</p>
+                    <p className="mt-3 text-4xl font-semibold text-text">218 routes</p>
+                    <p className="mt-1 text-sm text-muted">Synced across 12 data planes</p>
+                  </div>
+                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-neon-1/10 border border-neon-1/30">
+                    <Radar className="w-5 h-5 text-neon-1" />
+                  </div>
+                </div>
+
+                <div className="mt-8 space-y-4">
+                  <div className="flex items-center justify-between rounded-2xl border border-white/10 bg-white/[0.04] px-4 py-3">
+                    <div>
+                      <p className="text-xs uppercase tracking-widest text-muted">Carrier ETA</p>
+                      <p className="text-lg font-semibold text-text">98.2% on time</p>
+                    </div>
+                    <div className="flex items-center gap-1 text-xs text-emerald-300">
+                      <ArrowUpRight className="h-4 w-4" />
+                      <span>+4.3%</span>
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-3 text-sm text-muted">
+                    <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-3">
+                      <p className="text-xs uppercase tracking-widest text-muted/80">Risk alerts</p>
+                      <p className="mt-2 text-2xl font-semibold text-text">12</p>
+                      <p className="text-xs text-emerald-300 mt-1">-18% WoW</p>
+                    </div>
+                    <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-3">
+                      <p className="text-xs uppercase tracking-widest text-muted/80">CO₂ intensity</p>
+                      <p className="mt-2 text-2xl font-semibold text-text">0.82</p>
+                      <p className="text-xs text-sky-300 mt-1">kg / mi avg.</p>
+                    </div>
+                  </div>
+
+                  <div className="rounded-2xl border border-white/10 bg-gradient-to-r from-neon-1/10 via-transparent to-neon-2/10 px-4 py-4">
+                    <p className="text-xs uppercase tracking-widest text-muted">Scenario engine</p>
+                    <p className="mt-2 text-sm text-text/90 leading-relaxed">
+                      Snapshot future-state loads, pricing and risk scores before deploying
+                      into production.
+                    </p>
+                  </div>
+                </div>
+
+                <div className="absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-bg via-bg/60 to-transparent" />
+              </GlassCard>
+            </motion.div>
+
+            <motion.div
+              initial={{ opacity: 0, y: 80 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 1, delay: 0.4 }}
+              className="absolute -bottom-12 left-0 w-full max-w-[260px]"
+            >
+              <GlassCard hover={false} className="relative overflow-hidden rounded-3xl px-6 py-5">
+                <div className="absolute -top-10 -right-6 h-32 w-32 rounded-full bg-neon-2/20 blur-3xl" />
+                <div className="flex items-center gap-3">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-white/10 bg-white/[0.05]">
+                    <Workflow className="w-5 h-5 text-neon-1" />
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase tracking-widest text-muted">Autonomous TSM</p>
+                    <p className="text-lg font-semibold text-text">Runbook compiled</p>
+                  </div>
+                </div>
+                <ul className="mt-4 space-y-2 text-xs text-muted">
+                  <li className="flex items-center gap-2">
+                    <span className="h-1.5 w-1.5 rounded-full bg-neon-1" />
+                    8 microservices orchestrated
+                  </li>
+                  <li className="flex items-center gap-2">
+                    <span className="h-1.5 w-1.5 rounded-full bg-neon-2" />
+                    Robotics co-pilot engaged
+                  </li>
+                  <li className="flex items-center gap-2">
+                    <span className="h-1.5 w-1.5 rounded-full bg-neon-3" />
+                    SOC2 guardrail verified
+                  </li>
+                </ul>
+              </GlassCard>
+            </motion.div>
+
+            <motion.div
+              aria-hidden="true"
+              animate={{
+                y: [0, -18, 0],
+                rotate: [0, 6, 0]
+              }}
+              transition={{ duration: 10, repeat: Infinity, ease: "easeInOut" }}
+              className="absolute -top-16 right-24 h-40 w-40 rounded-full bg-neon-1/20 blur-3xl"
             />
-          </motion.div>
-        </motion.div>
+            <motion.div
+              aria-hidden="true"
+              animate={{
+                y: [0, 22, 0],
+                rotate: [0, -8, 0]
+              }}
+              transition={{ duration: 12, repeat: Infinity, ease: "easeInOut" }}
+              className="absolute top-24 -left-10 h-32 w-32 rounded-full bg-neon-2/20 blur-3xl"
+            />
+          </div>
+        </div>
       </div>
     </section>
   );

--- a/intleri-demo/src/components/MetricStat.tsx
+++ b/intleri-demo/src/components/MetricStat.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import { motion } from "framer-motion";
 import { TrendingUp, TrendingDown, Minus } from "lucide-react";
+import { cn } from "@/lib/utils";
 import GlassCard from "./GlassCard";
 
 interface MetricStatProps {
@@ -20,9 +23,9 @@ export default function MetricStat({
   const getTrendIcon = () => {
     switch (trend) {
       case "up":
-        return <TrendingUp className="w-4 h-4 text-green-400" />;
+        return <TrendingUp className="w-4 h-4 text-emerald-300" />;
       case "down":
-        return <TrendingDown className="w-4 h-4 text-red-400" />;
+        return <TrendingDown className="w-4 h-4 text-rose-400" />;
       default:
         return <Minus className="w-4 h-4 text-muted" />;
     }
@@ -31,34 +34,41 @@ export default function MetricStat({
   const getTrendColor = () => {
     switch (trend) {
       case "up":
-        return "text-green-400";
+        return "text-emerald-300";
       case "down":
-        return "text-red-400";
+        return "text-rose-400";
       default:
         return "text-muted";
     }
   };
 
   return (
-    <GlassCard hover className="text-center">
+    <GlassCard
+      hover
+      className={cn(
+        "relative overflow-hidden text-left",
+        "before:absolute before:inset-x-6 before:top-0 before:h-px before:bg-gradient-to-r before:from-transparent before:via-neon-1/60 before:to-transparent"
+      )}
+    >
+      <div className="pointer-events-none absolute -right-8 -top-8 h-24 w-24 rounded-full bg-neon-1/10 blur-3xl transition-transform duration-500 group-hover:scale-125" />
       <motion.div
         initial={{ opacity: 0, scale: 0.9 }}
         whileInView={{ opacity: 1, scale: 1 }}
         transition={{ duration: 0.5 }}
         viewport={{ once: true }}
       >
-        <h3 className="text-sm text-muted mb-2">{title}</h3>
-        <div className="text-3xl font-bold text-text mb-2">{value}</div>
-        
+        <h3 className="text-xs uppercase tracking-widest text-muted mb-3">{title}</h3>
+        <div className="text-4xl font-semibold text-text mb-3">{value}</div>
+
         {trendValue && (
-          <div className={`flex items-center justify-center space-x-1 ${getTrendColor()}`}>
+          <div className={cn("flex items-center gap-1 text-sm", getTrendColor())}>
             {getTrendIcon()}
-            <span className="text-sm">{trendValue}</span>
+            <span>{trendValue}</span>
           </div>
         )}
-        
+
         {description && (
-          <p className="text-xs text-muted mt-2">{description}</p>
+          <p className="text-xs text-muted/80 mt-3 leading-relaxed">{description}</p>
         )}
       </motion.div>
     </GlassCard>


### PR DESCRIPTION
## Summary
- redesign the landing hero to mirror Opera Neon's neon ambiance with animated glass previews, CTA updates, and highlight chips
- refresh the platform capabilities bento grid with richer feature copy, gradients, and supporting iconography
- add reusable ambient background utilities, upgrade glass cards, and modernize metric stat styling for consistent neon parity

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1e0933eb8832caa3fbb1fabb662c6